### PR TITLE
Fix: Improve guest list saving flow and authentication handling

### DIFF
--- a/src/app/guest-list/page.tsx
+++ b/src/app/guest-list/page.tsx
@@ -18,8 +18,8 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { Guest, OtherMealPreference } from "@/lib/types";
 import { AuthDialog } from "@/components/AuthDialog";
-import { auth, db } from "../lib/firebase"; // Added db
-import { useToast } from "../hooks/use-toast"; // Added import
+import { auth, db } from "@/lib/firebase"; // Changed path
+import { useToast } from "@/hooks/use-toast"; // Changed path
 import { doc, setDoc } from "firebase/firestore"; // Added firestore functions
 import { onAuthStateChanged } from "firebase/auth"; // Added onAuthStateChanged
 


### PR DESCRIPTION
This commit addresses an issue where you were asked to log in again when trying to save a guest list, even if already authenticated.

Changes implemented:
- Modified the guest list page to check Firebase authentication status before prompting for login.
- Implemented functionality to save the guest list to Firestore (under users/{userId}/guestLists/mainList) if you are logged in.
- Added logic to automatically save the list after you log in successfully via the email magic link flow.
- Introduced a loading state for the save operation, disabling the "Save List" button and providing visual feedback during the save.
- Ensured appropriate toast notifications are displayed for various scenarios (save success/failure, login prompts, cancellations).